### PR TITLE
Reverse plot y orientation due to swapping of y and z values

### DIFF
--- a/tests/plotting/plot_animation.py
+++ b/tests/plotting/plot_animation.py
@@ -67,7 +67,7 @@ ax.set_zlabel('Y')
 
 ax.set_xlim3d([-0.2, 0.2])
 ax.set_zlim3d([0, 0.4])
-ax.set_ylim3d([-0.2,0.2])
+ax.set_ylim3d([0.2,-0.2])
 
 # Set azimtuth and elevation of plot
 # ax.view_init(elev=135,azim=0)

--- a/tests/plotting/plot_body.py
+++ b/tests/plotting/plot_body.py
@@ -21,7 +21,7 @@ ax.set_zlabel('Y')
 
 ax.set_xlim3d([-0.2, 0.2])
 ax.set_zlim3d([0, 0.4])
-ax.set_ylim3d([-0.2,0.2])
+ax.set_ylim3d([0.2,-0.2])
 
 # Set azimtuth and elevation of plot
 # ax.view_init(elev=135,azim=0)

--- a/tests/plotting/plot_single_leg.py
+++ b/tests/plotting/plot_single_leg.py
@@ -22,7 +22,7 @@ ax.set_ylabel('Z')
 
 ax.set_xlim3d([-0.15, 0.15])
 ax.set_zlim3d([-0.25, 0.05])
-ax.set_ylim3d([-0.15,0.15])
+ax.set_ylim3d([0.15,-0.15])
 
 # ax.invert_yaxis()
 


### PR DESCRIPTION
Fix plotting orientation so left/right legs actually reflect angles of left/right legs.

This is due to a plotting only artifact of swapping y and z values for better visualization in a matplot 3d plot.

Address #2 