### PR TITLE
updating comments on leg matrix t01 to show differences between origi…

### DIFF
--- a/utilities/spot_micro_kinematics.py
+++ b/utilities/spot_micro_kinematics.py
@@ -100,7 +100,7 @@ def t_0_to_1(theta1,l1):
     # I believe there is a typo in the paper. The paper lists this matrix as:
     # 
     # t =    [ cos(theta1)     -sin(theta1)    0        -l1*cos(theta1);
-    #          sin(theta1)     -cos(theta1)    0        -l1*sin(theta1);
+    #          sin(theta1)     cos(theta1)    0        -l1*sin(theta1);
     #                    1                0    0                      0;
     #                    0                0    0                      1;]
     # 
@@ -109,7 +109,7 @@ def t_0_to_1(theta1,l1):
     # axis's z axis is the same as the original. So I think the matrix should be:
     # 
     # t =    [ cos(theta1)     -sin(theta1)    0        -l1*cos(theta1);
-    #          sin(theta1)     -cos(theta1)    0        -l1*sin(theta1);
+    #          sin(theta1)     cos(theta1)    0        -l1*sin(theta1);
     #                    0                0    1                      0;d
     #                    0                0    0                      1;]
     


### PR DESCRIPTION
Thanks for going through the paper and finding the discrepancies with matrix t01 and t12. It helped me a lot as I was looking through this. I found one typo I think in the comments of your code, where the paper t01 matrix i see here https://www.ijstr.org/final-print/sep2017/Inverse-Kinematic-Analysis-Of-A-Quadruped-Robot.pdf in row index 1 col index 1 has positive cos(theta1).
![image](https://user-images.githubusercontent.com/46413365/223121935-9c4cf2bb-4065-4a9f-8aa2-b2d73962f7ed.png)

The matrix in the paper still has weird stuff going on in the row index 2. I only threw this PR out as the comments confused me slightly as I was comparing the matrices in your comments to the paper.

I agree with you, and did out the matrix math using their DH parameters and arrive at the same thing you got.
https://wikimedia.org/api/rest_v1/media/math/render/svg/6963d0c47a3a894ff0719c8df348d188b996074e

| joint i  | theta i (degree)  | alpha i (degree)  |  r i (meters) |  d i (meters) |
|---|---|---|---|---|
|  0-1 | theta1   |  0 |  l1 | 0  |

Looking at t01:  
|||||
|---|---|---|---|
| cos(theta1) | -sin(theta1)*cos(0) | sin(theta1) * sin(0) | -l1 * cos(theta1) |
|sin(theta1) | cos(theta1) * cos(0) | -cos(theta1) * sin(0) | -l1 * sin(theta1) |
|0 | sin(0) | cos(0) | 0 |
|0|0|0|1|


so that is:
|||||
|---|---|---|---|
| cos(theta1) | -sin(theta1)* 1 | sin(theta1) * 0 | -l1 * cos(theta1)|
| sin(theta1) | cos(theta1) * 1 | -cos(theta1) * 0| -l1 * sin(theta1) |
|0 | 0 | 1 | 0 |
|0|0|0|1|


so that is:
|||||
|---|---|---|---|
| cos(theta1) | -sin(theta1) | 0 | -l1 * cos(theta1) |
| sin(theta1) | cos(theta1)| 0 | -l1 * sin(theta1) |
|0 | 0 | 1 | 0 |
|0|0|0|1|

I did the same thing for matrix t12, and also got something that agrees with you, just with a different sign on the 1 in row index 2. This is probably do to spot micro doing legs pointing back, and alpha being positive pi/2 instead of -pi/2 as in the paper model.